### PR TITLE
Add `data-show` to simple example

### DIFF
--- a/templates/simple-reactive/index.twig
+++ b/templates/simple-reactive/index.twig
@@ -30,13 +30,15 @@
             #}
             <h3 class="text-3xl p-3">Type something:</h3>
             <input
-                class="input w-full max-w-xs p-3"
+                class="input input-bordered w-full max-w-xs"
                 data-model="input"
-                data-on-input.debounce_500ms="{{ spark('_spark/faceted-search.twig') }}"
                 placeholder=""
                 type="text"
             />
-            <p class="text-3xl p-3" data-text="$input"></p>
+            <p class="text-3xl p-3">
+                <span data-text="$input"></span>
+                <span data-show="$input == 'Toronto'">🇨🇦</span>
+            </p>
         </div>
     </section>
 {% endblock %}


### PR DESCRIPTION
Adds an element that uses `data-show` to output an emoji when `Toronto` is enetered. Also adds a border to the input field.

![screenshot-iMFCA39V@2x](https://github.com/user-attachments/assets/126d880d-62bb-4ab0-b5d3-6d18e4dfc8c4)
